### PR TITLE
Add clash indicator to SUBS tab

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,6 +23,7 @@ export default function Home() {
   const [scanlines, setScanlines] = useState(false);
   const [basho, setBasho] = useState("");
   const [currentDay, setCurrentDay] = useState(0);
+  const [hasSubClash, setHasSubClash] = useState(false);
 
   useEffect(() => {
     setActiveTab(tabFromHash());
@@ -42,6 +43,18 @@ export default function Home() {
       setCurrentDay(lbData.currentDay || 0);
     });
   }, []);
+
+  useEffect(() => {
+    if (!session || currentDay === 0) return;
+    Promise.all([
+      fetch(`/api/stable?userId=${session.userId}`).then((r) => r.json()),
+      fetch("/api/basho/bouts").then((r) => r.json()),
+    ]).then(([stableData, boutsData]) => {
+      const stableIds = new Set<number>((stableData.stable ?? []).map((s: { rikishi_id: number }) => s.rikishi_id));
+      const nextDayBouts: { east_id: number; west_id: number }[] = boutsData.boutsByDay?.[currentDay + 1] ?? [];
+      setHasSubClash(nextDayBouts.some((b) => stableIds.has(b.east_id) && stableIds.has(b.west_id)));
+    });
+  }, [session, currentDay]);
 
   const navigateTo = (tab: Tab) => {
     window.history.pushState(null, "", `#${tab}`);
@@ -116,6 +129,9 @@ export default function Home() {
                   }`}
                 >
                   {tab.label}
+                  {tab.id === "substitution" && hasSubClash && (
+                    <span className="text-retro-red ml-1">!</span>
+                  )}
                 </button>
               );
             })}


### PR DESCRIPTION
## Summary

- Fetches the logged-in user's stable and next day's bouts on page load
- Detects stablemate clashes (two wrestlers from the same stable facing each other)
- Shows a red `!` next to the SUBS tab label when a clash is detected
- Indicator is visible regardless of whether the substitution window is open

## Test plan

- [ ] Log in as a user whose stable has a stablemate clash scheduled for the next day — SUBS tab should show `SUBS !` in red
- [ ] Log in as a user with no clash — SUBS tab should show `SUBS` with no indicator
- [ ] Verify indicator appears when the substitution window is closed (not just when open)
- [ ] Verify indicator disappears after making a sub that resolves the clash

🤖 Generated with [Claude Code](https://claude.com/claude-code)