### PR TITLE
feat: password-based auth with front page lockdown

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -6,7 +6,7 @@
 
 The app pulls real match data from the `sumo-api.com` public API, automatically calculates scores, and displays a live leaderboard. Users can make limited substitutions to their stable each evening. The visual theme is inspired by 80s Japanese 8-bit sports games, specifically the Kunio-kun / Nekketsu series.
 
-The app is designed for a small, trusted group of 5-15 users defined in a config file. There is no full authentication system -- users select their name from a dropdown and enter a simple 4-digit PIN to make changes.
+The app is designed for a small, trusted group of 5-15 users defined in a config file. Users authenticate with a password (bcrypt-hashed, stored in SQLite). All pages and API routes require authentication -- nothing is visible without logging in.
 
 ## Goals & Non-Goals
 
@@ -18,10 +18,10 @@ The app is designed for a small, trusted group of 5-15 users defined in a config
 - Support mid-basho wrestler substitutions (up to 2 per day within a defined window)
 - Award bonus points for kimboshi (Maegashira beating a Yokozuna)
 - Deliver a fun, retro 8-bit Kunio-kun visual experience
+- Secure all pages and API routes behind password-based authentication
 
 ### Non-Goals
 
-- Full user authentication / account creation system
 - Multi-basho / seasonal cumulative scoring -- each basho is standalone
 - Coverage of lower divisions (Juryo, Makushita, etc.) -- Makuuchi only
 - Mobile app -- web-only, responsive design
@@ -29,11 +29,28 @@ The app is designed for a small, trusted group of 5-15 users defined in a config
 
 ## Users & Access
 
-Users are defined in a JSON or YAML config file managed by an admin. Each user entry contains a display name, a 4-digit PIN, and an `admin` boolean flag. Admin users can trigger manual data syncs and manage basho settings. There is no registration flow -- users are added manually by the person running the app.
+Users are defined in `config.json` managed by an admin. Each user entry contains a display name, an optional legacy PIN (for migration), and an `admin` boolean flag. Admin users can trigger manual data syncs and manage user passwords.
 
-To interact with the site, a user selects their name from a dropdown and enters their PIN. The PIN is a lightweight guard against accidental changes -- it is not a security mechanism against determined attackers. PINs are stored in plaintext in the config file since the threat model is "trusted friends."
+### Authentication
 
-The config file also defines the timezone for the substitution window (AEST) and other app-level settings like the current basho identifier.
+Users authenticate with a password (minimum 8 characters). Passwords are hashed with bcrypt (cost factor 10) and stored in the `users` SQLite table. Sessions are managed via a `rikishi-session` cookie (non-HttpOnly, SameSite=Lax, 30-day expiry) containing `{ userId, name, admin }`.
+
+All pages and API routes are protected:
+- **Next.js middleware** gates all `/api/*` routes (except `/api/auth/*`) — returns 401 without a valid session cookie
+- **Front page** shows only a login form when not authenticated — no leaderboard, basho info, or tabs are visible
+- **API routes** that perform writes additionally validate the session to determine user identity (replacing the old PIN-in-body approach)
+
+### Migration from PIN
+
+Existing users who have not yet set a password are prompted to do so on first login:
+1. User enters their old 4-digit PIN as "password"
+2. Server validates the PIN against `config.json` and returns `needsPassword: true`
+3. User sets a new password (8+ chars) via the "Set Your Password" form
+4. Future logins use the new password only
+
+Admins can reset a user's password (clears `password_hash`), forcing them through the PIN migration flow again.
+
+The config file defines the timezone for the substitution window (AEST) and other app-level settings like the current basho identifier.
 
 **Example config structure:**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rikishi-rumble",
       "version": "0.1.0",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.6.2",
         "next": "16.1.6",
         "node-cron": "^4.2.1",
@@ -16,6 +17,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/bcryptjs": "^2.4.6",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20",
         "@types/node-cron": "^3.0.11",
@@ -1528,6 +1530,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -2483,6 +2492,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/better-sqlite3": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.6.2",
     "next": "16.1.6",
     "node-cron": "^4.2.1",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/bcryptjs": "^2.4.6",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20",
     "@types/node-cron": "^3.0.11",

--- a/src/app/api/admin/pin/route.ts
+++ b/src/app/api/admin/pin/route.ts
@@ -1,44 +1,38 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isAdmin, validatePin, updateUserPin, getConfig } from "@/lib/config";
+import { getSessionFromRequest } from "@/lib/auth";
+import { getDb } from "@/lib/db";
 
 export async function POST(request: NextRequest) {
-  const { adminName, adminPin, targetUser, newPin } = await request.json();
-
-  if (!adminName || !adminPin || !targetUser || !newPin) {
-    return NextResponse.json(
-      { error: "adminName, adminPin, targetUser, and newPin required" },
-      { status: 400 }
-    );
-  }
-
-  if (!validatePin(adminName, adminPin)) {
-    return NextResponse.json({ error: "Invalid admin PIN" }, { status: 401 });
-  }
-
-  if (!isAdmin(adminName)) {
+  const session = getSessionFromRequest(request);
+  if (!session || !session.admin) {
     return NextResponse.json(
       { error: "Admin access required" },
       { status: 403 }
     );
   }
 
-  if (!/^\d{4}$/.test(newPin)) {
+  const { targetUser } = await request.json();
+
+  if (!targetUser) {
     return NextResponse.json(
-      { error: "PIN must be exactly 4 digits" },
+      { error: "targetUser required" },
       { status: 400 }
     );
   }
 
-  const config = getConfig();
-  const target = config.users.find((u) => u.name === targetUser);
-  if (!target) {
+  const db = getDb();
+  const targetId = targetUser.toLowerCase().replace(/\s+/g, "-");
+  const user = db.prepare("SELECT id FROM users WHERE id = ?").get(targetId);
+
+  if (!user) {
     return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
 
-  const success = updateUserPin(targetUser, newPin);
-  if (!success) {
-    return NextResponse.json({ error: "Failed to update PIN" }, { status: 500 });
-  }
+  // Clear password_hash so the user must re-authenticate with their PIN and set a new password
+  db.prepare("UPDATE users SET password_hash = NULL WHERE id = ?").run(targetId);
 
-  return NextResponse.json({ success: true, message: `PIN updated for ${targetUser}` });
+  return NextResponse.json({
+    success: true,
+    message: `Password reset for ${targetUser}. They will need to set a new password on next login.`,
+  });
 }

--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -1,26 +1,73 @@
 import { NextRequest, NextResponse } from "next/server";
-import { validatePin, isAdmin, getConfig } from "@/lib/config";
+import { validatePin, getConfig } from "@/lib/config";
+import { getDb } from "@/lib/db";
+import {
+  verifyPassword,
+  SESSION_COOKIE,
+  SESSION_MAX_AGE,
+  makeSessionCookieValue,
+} from "@/lib/auth";
 
 export async function POST(request: NextRequest) {
-  const { name, pin } = await request.json();
+  const { name, password } = await request.json();
 
-  if (!name || !pin) {
+  if (!name || !password) {
     return NextResponse.json(
-      { error: "Name and PIN required" },
+      { error: "Name and password required" },
       { status: 400 }
     );
   }
 
-  if (!validatePin(name, pin)) {
-    return NextResponse.json({ error: "Invalid PIN" }, { status: 401 });
+  const userId = name.toLowerCase().replace(/\s+/g, "-");
+  const db = getDb();
+  const user = db
+    .prepare("SELECT id, name, password_hash, admin FROM users WHERE id = ?")
+    .get(userId) as
+    | { id: string; name: string; password_hash: string | null; admin: number }
+    | undefined;
+
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 401 });
   }
 
-  const userId = name.toLowerCase().replace(/\s+/g, "-");
+  // User has a password set — verify with bcrypt
+  if (user.password_hash) {
+    if (!verifyPassword(password, user.password_hash)) {
+      return NextResponse.json(
+        { error: "Invalid password" },
+        { status: 401 }
+      );
+    }
 
+    const session = { userId: user.id, name: user.name, admin: !!user.admin };
+    const response = NextResponse.json({
+      userId: session.userId,
+      name: session.name,
+      admin: session.admin,
+    });
+    response.cookies.set(SESSION_COOKIE, makeSessionCookieValue(session), {
+      path: "/",
+      sameSite: "lax",
+      maxAge: SESSION_MAX_AGE,
+      httpOnly: false,
+    });
+    return response;
+  }
+
+  // No password yet — validate old PIN for migration
+  if (!validatePin(name, password)) {
+    return NextResponse.json(
+      { error: "Invalid PIN" },
+      { status: 401 }
+    );
+  }
+
+  // PIN valid but no password set — prompt to set one
   return NextResponse.json({
-    userId,
-    name,
-    admin: isAdmin(name),
+    userId: user.id,
+    name: user.name,
+    admin: !!user.admin,
+    needsPassword: true,
   });
 }
 

--- a/src/app/api/auth/set-password/route.ts
+++ b/src/app/api/auth/set-password/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validatePin } from "@/lib/config";
+import { getDb } from "@/lib/db";
+import {
+  hashPassword,
+  SESSION_COOKIE,
+  SESSION_MAX_AGE,
+  makeSessionCookieValue,
+} from "@/lib/auth";
+
+export async function POST(request: NextRequest) {
+  const { name, pin, password } = await request.json();
+
+  if (!name || !pin || !password) {
+    return NextResponse.json(
+      { error: "Name, PIN, and new password required" },
+      { status: 400 }
+    );
+  }
+
+  if (password.length < 8) {
+    return NextResponse.json(
+      { error: "Password must be at least 8 characters" },
+      { status: 400 }
+    );
+  }
+
+  const userId = name.toLowerCase().replace(/\s+/g, "-");
+  const db = getDb();
+  const user = db
+    .prepare("SELECT id, name, password_hash, admin FROM users WHERE id = ?")
+    .get(userId) as
+    | { id: string; name: string; password_hash: string | null; admin: number }
+    | undefined;
+
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 401 });
+  }
+
+  // Only allow set-password if user hasn't set one yet
+  if (user.password_hash) {
+    return NextResponse.json(
+      { error: "Password already set. Use login instead." },
+      { status: 400 }
+    );
+  }
+
+  // Validate PIN one final time
+  if (!validatePin(name, pin)) {
+    return NextResponse.json({ error: "Invalid PIN" }, { status: 401 });
+  }
+
+  // Hash and store the new password
+  const hash = hashPassword(password);
+  db.prepare("UPDATE users SET password_hash = ? WHERE id = ?").run(hash, userId);
+
+  const session = { userId: user.id, name: user.name, admin: !!user.admin };
+  const response = NextResponse.json({
+    userId: session.userId,
+    name: session.name,
+    admin: session.admin,
+  });
+  response.cookies.set(SESSION_COOKIE, makeSessionCookieValue(session), {
+    path: "/",
+    sameSite: "lax",
+    maxAge: SESSION_MAX_AGE,
+    httpOnly: false,
+  });
+  return response;
+}

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getSessionFromRequest } from "@/lib/auth";
 
 export async function POST(request: NextRequest) {
-  const { userName } = await request.json();
-
-  if (userName !== "Matt") {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const session = getSessionFromRequest(request);
+  if (!session || !session.admin) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
   }
 
   const { startCronJobs } = await import("@/lib/cron");

--- a/src/app/api/stable/route.ts
+++ b/src/app/api/stable/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
-import { getConfig, validatePin } from "@/lib/config";
+import { getConfig } from "@/lib/config";
+import { getSessionFromRequest } from "@/lib/auth";
 
 export async function GET(request: NextRequest) {
   const userId = request.nextUrl.searchParams.get("userId");
@@ -57,22 +58,23 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const { userName, pin, picks } = await request.json();
+  const session = getSessionFromRequest(request);
+  if (!session) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
 
-  if (!userName || !pin || !picks) {
+  const { picks } = await request.json();
+
+  if (!picks) {
     return NextResponse.json(
-      { error: "userName, pin, and picks required" },
+      { error: "picks required" },
       { status: 400 }
     );
   }
 
-  if (!validatePin(userName, pin)) {
-    return NextResponse.json({ error: "Invalid PIN" }, { status: 401 });
-  }
-
   const config = getConfig();
   const bashoId = config.basho;
-  const userId = userName.toLowerCase().replace(/\s+/g, "-");
+  const userId = session.userId;
   const db = getDb();
 
   // Validate picks: must have exactly 5 picks, one per tier

--- a/src/app/api/substitution/route.ts
+++ b/src/app/api/substitution/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
-import { getConfig, validatePin } from "@/lib/config";
+import { getConfig } from "@/lib/config";
 import { isSubstitutionWindowOpen } from "@/lib/substitution";
+import { getSessionFromRequest } from "@/lib/auth";
 
 export async function GET(request: NextRequest) {
   const userId = request.nextUrl.searchParams.get("userId");
@@ -34,17 +35,18 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const { userName, pin, tier, newRikishiId, day } = await request.json();
-
-  if (!userName || !pin || !tier || !newRikishiId || !day) {
-    return NextResponse.json(
-      { error: "userName, pin, tier, newRikishiId, and day required" },
-      { status: 400 }
-    );
+  const session = getSessionFromRequest(request);
+  if (!session) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
 
-  if (!validatePin(userName, pin)) {
-    return NextResponse.json({ error: "Invalid PIN" }, { status: 401 });
+  const { tier, newRikishiId, day } = await request.json();
+
+  if (!tier || !newRikishiId || !day) {
+    return NextResponse.json(
+      { error: "tier, newRikishiId, and day required" },
+      { status: 400 }
+    );
   }
 
   if (!isSubstitutionWindowOpen()) {
@@ -56,7 +58,7 @@ export async function POST(request: NextRequest) {
 
   const config = getConfig();
   const bashoId = config.basho;
-  const userId = userName.toLowerCase().replace(/\s+/g, "-");
+  const userId = session.userId;
   const db = getDb();
 
   // Check daily substitution limit (2 per day)

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,17 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getConfig, isAdmin } from "@/lib/config";
+import { getConfig } from "@/lib/config";
 import { syncBanzuke, syncAllDays, syncDay, calculateScores } from "@/lib/sync";
+import { getSessionFromRequest } from "@/lib/auth";
 
 export async function POST(request: NextRequest) {
-  const { userName, action, day } = await request.json();
-
-  if (!userName || !isAdmin(userName)) {
+  const session = getSessionFromRequest(request);
+  if (!session || !session.admin) {
     return NextResponse.json(
       { error: "Admin access required" },
       { status: 403 }
     );
   }
 
+  const { action, day } = await request.json();
   const config = getConfig();
   const bashoId = config.basho;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,41 +10,44 @@ import { BashoPage } from "@/components/BashoPage";
 import { RulesPanel } from "@/components/RulesPanel";
 import { bashoLabel } from "@/lib/basho";
 
-type Tab = "leaderboard" | "basho" | "rules" | "stable" | "substitution" | "admin";
-const VALID_TABS = new Set<Tab>(["leaderboard", "basho", "rules", "stable", "substitution", "admin"]);
+type Tab = "home" | "leaderboard" | "basho" | "rules" | "stable" | "substitution" | "admin";
+const VALID_TABS = new Set<Tab>(["home", "leaderboard", "basho", "rules", "stable", "substitution", "admin"]);
 
-function tabFromHash(): Tab {
+function tabFromHash(loggedIn: boolean): Tab {
   const hash = window.location.hash.slice(1);
-  return VALID_TABS.has(hash as Tab) ? (hash as Tab) : "leaderboard";
+  if (VALID_TABS.has(hash as Tab)) return hash as Tab;
+  return loggedIn ? "leaderboard" : "home";
 }
 
 export default function Home() {
   const { session, login, logout } = useAuth();
-  const [activeTab, setActiveTab] = useState<Tab>("leaderboard");
-  const [pin, setPin] = useState("");
+  const [activeTab, setActiveTab] = useState<Tab>("home");
   const scanlines = true;
   const [basho, setBasho] = useState("");
   const [currentDay, setCurrentDay] = useState(0);
   const [hasSubClash, setHasSubClash] = useState(false);
 
   useEffect(() => {
-    setActiveTab(tabFromHash());
-    const onPopState = () => setActiveTab(tabFromHash());
+    setActiveTab(tabFromHash(!!session));
+    const onPopState = () => setActiveTab(tabFromHash(!!session));
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
+  }, [session]);
+
+  // Fetch basho info (public endpoint) always
+  useEffect(() => {
+    fetch("/api/basho")
+      .then((r) => r.json())
+      .then((data) => setBasho(data.basho || ""));
   }, []);
 
+  // Fetch leaderboard data when logged in
   useEffect(() => {
-    const stored = localStorage.getItem("rikishi-pin");
-    if (stored) setPin(stored);
-    Promise.all([
-      fetch("/api/basho").then((r) => r.json()),
-      fetch("/api/leaderboard").then((r) => r.json()),
-    ]).then(([bashoData, lbData]) => {
-      setBasho(bashoData.basho || "");
-      setCurrentDay(lbData.currentDay || 0);
-    });
-  }, []);
+    if (!session) return;
+    fetch("/api/leaderboard")
+      .then((r) => r.json())
+      .then((data) => setCurrentDay(data.currentDay || 0));
+  }, [session]);
 
   useEffect(() => {
     if (!session || currentDay === 0) return;
@@ -65,28 +68,31 @@ export default function Home() {
 
   const handleLogin = (user: { userId: string; name: string; admin: boolean }) => {
     login(user);
-    const pinInput = document.querySelector<HTMLInputElement>('input[type="password"]');
-    if (pinInput) {
-      setPin(pinInput.value);
-      localStorage.setItem("rikishi-pin", pinInput.value);
-    }
+    navigateTo("leaderboard");
   };
 
   const handleLogout = () => {
     logout();
-    setPin("");
-    localStorage.removeItem("rikishi-pin");
-    navigateTo("leaderboard");
+    navigateTo("home");
   };
 
-  const tabs: { id: Tab; label: string; requiresAuth?: boolean; requiresAdmin?: boolean }[] = [
+  // Tabs for logged-in users
+  const authedTabs: { id: Tab; label: string; requiresAdmin?: boolean }[] = [
     { id: "leaderboard", label: "SCORES" },
     { id: "basho", label: "BASHO" },
-    { id: "stable", label: "STABLE", requiresAuth: true },
-    { id: "substitution", label: "SUBS", requiresAuth: true },
+    { id: "stable", label: "STABLE" },
+    { id: "substitution", label: "SUBS" },
     { id: "rules", label: "RULES" },
-    { id: "admin", label: "ADMIN", requiresAuth: true, requiresAdmin: true },
+    { id: "admin", label: "ADMIN", requiresAdmin: true },
   ];
+
+  // Tabs for landing page (not logged in)
+  const publicTabs: { id: Tab; label: string }[] = [
+    { id: "home", label: "HOME" },
+    { id: "rules", label: "RULES" },
+  ];
+
+  const visibleTabs = session ? authedTabs : publicTabs;
 
   return (
     <div className={`min-h-screen ${scanlines ? "scanlines" : ""}`}>
@@ -113,9 +119,8 @@ export default function Home() {
           </div>
 
           <nav className="flex gap-1 overflow-x-auto">
-            {tabs.map((tab) => {
-              if (tab.requiresAuth && !session) return null;
-              if (tab.requiresAdmin && !session?.admin) return null;
+            {visibleTabs.map((tab) => {
+              if ("requiresAdmin" in tab && tab.requiresAdmin && !session?.admin) return null;
               return (
                 <button
                   key={tab.id}
@@ -136,17 +141,44 @@ export default function Home() {
       </header>
 
       <main className="max-w-4xl mx-auto px-3 sm:px-4 py-4 sm:py-6">
-        {activeTab === "leaderboard" && <Leaderboard />}
-
-        {activeTab === "basho" && <BashoPage userName={session?.name} />}
+        {/* Public pages */}
+        {activeTab === "home" && !session && (
+          <div className="retro-panel">
+            <div className="retro-panel-header">
+              <h2 className="font-pixel text-sm">WELCOME</h2>
+            </div>
+            <div className="space-y-4 font-pixel text-xs">
+              <p className="text-retro-cyan">
+                WELCOME TO RIKISHI RUMBLE - THE SUMO TIPPING GAME!
+              </p>
+              <p className="text-gray-300">
+                BUILD YOUR STABLE OF 5 WRESTLERS ACROSS 5 RANK TIERS.
+                EARN POINTS WHEN YOUR WRESTLERS WIN THEIR BOUTS DURING
+                THE 15-DAY BASHO TOURNAMENT.
+              </p>
+              <p className="text-gray-300">
+                SCORE BONUS KIMBOSHI POINTS WHEN YOUR MAEGASHIRA
+                DEFEATS A YOKOZUNA. MAKE STRATEGIC SUBSTITUTIONS EACH
+                EVENING TO STAY AHEAD OF THE COMPETITION.
+              </p>
+              <p className="text-retro-yellow">
+                LOG IN TO GET STARTED!
+              </p>
+            </div>
+          </div>
+        )}
 
         {activeTab === "rules" && <RulesPanel />}
+
+        {/* Authenticated pages */}
+        {activeTab === "leaderboard" && session && <Leaderboard />}
+
+        {activeTab === "basho" && session && <BashoPage userName={session?.name} />}
 
         {activeTab === "stable" && session && (
           <StableSelector
             userId={session.userId}
             userName={session.name}
-            pin={pin}
           />
         )}
 
@@ -154,12 +186,11 @@ export default function Home() {
           <SubstitutionPanel
             userId={session.userId}
             userName={session.name}
-            pin={pin}
           />
         )}
 
         {activeTab === "admin" && session?.admin && (
-          <AdminPanel userName={session.name} pin={pin} />
+          <AdminPanel userName={session.name} />
         )}
       </main>
 

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -7,13 +7,12 @@ interface UserOption {
   name: string;
 }
 
-export function AdminPanel({ userName, pin }: { userName: string; pin: string }) {
+export function AdminPanel({ userName }: { userName: string }) {
   const [syncing, setSyncing] = useState(false);
   const [message, setMessage] = useState("");
   const [users, setUsers] = useState<UserOption[]>([]);
   const [selectedUser, setSelectedUser] = useState("");
-  const [newPin, setNewPin] = useState("");
-  const [pinMessage, setPinMessage] = useState("");
+  const [resetMessage, setResetMessage] = useState("");
   const [autoSyncDay, setAutoSyncDay] = useState<number | null>(null);
   const autoSyncInterval = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -39,7 +38,7 @@ export function AdminPanel({ userName, pin }: { userName: string; pin: string })
     const res = await fetch("/api/sync", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ userName, action: "day", day }),
+      body: JSON.stringify({ action: "day", day }),
     });
     const data = await res.json();
     if (res.ok) {
@@ -49,7 +48,7 @@ export function AdminPanel({ userName, pin }: { userName: string; pin: string })
       setMessage(data.error || "SYNC FAILED");
       return false;
     }
-  }, [userName]);
+  }, []);
 
   const handleSync = async (action: string, day?: number) => {
     stopAutoSync();
@@ -74,7 +73,7 @@ export function AdminPanel({ userName, pin }: { userName: string; pin: string })
     const res = await fetch("/api/sync", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ userName, action, day }),
+      body: JSON.stringify({ action, day }),
     });
 
     const data = await res.json();
@@ -140,30 +139,31 @@ export function AdminPanel({ userName, pin }: { userName: string; pin: string })
         )}
       </div>
 
-      {/* Cron control — Matt only */}
-      {userName === "Matt" && (
-        <div className="mt-4 border-t-2 border-retro-border pt-4">
-          <h3 className="font-pixel text-xs text-retro-cyan mb-3">CRON JOBS</h3>
-          <button
-            onClick={async () => {
-              const res = await fetch("/api/cron", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ userName }),
-              });
-              const data = await res.json();
-              setMessage(data.message || data.error || "DONE");
-            }}
-            className="retro-btn w-full text-xs py-2"
-          >
-            START CRON JOBS
-          </button>
-        </div>
-      )}
-
-      {/* PIN Management */}
+      {/* Cron control */}
       <div className="mt-4 border-t-2 border-retro-border pt-4">
-        <h3 className="font-pixel text-xs text-retro-cyan mb-3">CHANGE USER PIN</h3>
+        <h3 className="font-pixel text-xs text-retro-cyan mb-3">CRON JOBS</h3>
+        <button
+          onClick={async () => {
+            const res = await fetch("/api/cron", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({}),
+            });
+            const data = await res.json();
+            setMessage(data.message || data.error || "DONE");
+          }}
+          className="retro-btn w-full text-xs py-2"
+        >
+          START CRON JOBS
+        </button>
+      </div>
+
+      {/* Password Reset */}
+      <div className="mt-4 border-t-2 border-retro-border pt-4">
+        <h3 className="font-pixel text-xs text-retro-cyan mb-3">RESET USER PASSWORD</h3>
+        <p className="font-pixel text-xs text-gray-400 mb-2">
+          RESETS PASSWORD SO USER MUST SET A NEW ONE VIA PIN
+        </p>
         <div className="flex items-center gap-2 flex-wrap">
           <select
             value={selectedUser}
@@ -177,45 +177,31 @@ export function AdminPanel({ userName, pin }: { userName: string; pin: string })
               </option>
             ))}
           </select>
-          <input
-            type="text"
-            maxLength={4}
-            placeholder="NEW PIN"
-            value={newPin}
-            onChange={(e) => setNewPin(e.target.value.replace(/\D/g, ""))}
-            className="retro-input w-20 text-xs text-center"
-          />
           <button
             onClick={async () => {
-              setPinMessage("");
+              setResetMessage("");
               const res = await fetch("/api/admin/pin", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  adminName: userName,
-                  adminPin: pin,
-                  targetUser: selectedUser,
-                  newPin,
-                }),
+                body: JSON.stringify({ targetUser: selectedUser }),
               });
               const data = await res.json();
-              setPinMessage(data.message || data.error);
+              setResetMessage(data.message || data.error);
               if (res.ok) {
-                setNewPin("");
                 setSelectedUser("");
               }
             }}
-            disabled={!selectedUser || newPin.length !== 4}
+            disabled={!selectedUser}
             className="retro-btn text-xs px-3 py-1"
           >
-            UPDATE
+            RESET
           </button>
         </div>
-        {pinMessage && (
+        {resetMessage && (
           <p className={`font-pixel text-xs mt-2 ${
-            pinMessage.startsWith("PIN") ? "text-retro-green" : "text-retro-red"
+            resetMessage.startsWith("Password") ? "text-retro-green" : "text-retro-red"
           }`}>
-            {pinMessage}
+            {resetMessage}
           </p>
         )}
       </div>

--- a/src/components/StableSelector.tsx
+++ b/src/components/StableSelector.tsx
@@ -52,11 +52,9 @@ function useCountdown(targetDate: Date | null) {
 export function StableSelector({
   userId,
   userName,
-  pin,
 }: {
   userId: string;
   userName: string;
-  pin: string;
 }) {
   const [wrestlers, setWrestlers] = useState<Wrestler[]>([]);
   const [picks, setPicks] = useState<Record<number, number>>({});
@@ -114,7 +112,7 @@ export function StableSelector({
     const res = await fetch("/api/stable", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ userName, pin, picks: picksArray }),
+      body: JSON.stringify({ picks: picksArray }),
     });
 
     if (res.ok) {

--- a/src/components/SubstitutionPanel.tsx
+++ b/src/components/SubstitutionPanel.tsx
@@ -112,11 +112,9 @@ function detectClashes(stableIds: Set<number>, bouts: Bout[]): ClashInfo[] {
 export function SubstitutionPanel({
   userId,
   userName,
-  pin,
 }: {
   userId: string;
   userName: string;
-  pin: string;
 }) {
   const [stable, setStable] = useState<StableEntry[]>([]);
   const [wrestlers, setWrestlers] = useState<Wrestler[]>([]);
@@ -178,8 +176,6 @@ export function SubstitutionPanel({
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        userName,
-        pin,
         tier,
         newRikishiId,
         day: currentDay,

--- a/src/components/UserAuth.tsx
+++ b/src/components/UserAuth.tsx
@@ -2,38 +2,46 @@
 
 import { useState, useEffect } from "react";
 
-interface UserSession {
+export interface UserSession {
   userId: string;
   name: string;
   admin: boolean;
 }
 
-interface UserOption {
-  id: string;
-  name: string;
-}
-
 export function useAuth() {
   const [session, setSession] = useState<UserSession | null>(null);
-  const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
-    const stored = localStorage.getItem("rikishi-session");
-    if (stored) setSession(JSON.parse(stored));
-    setHydrated(true);
+    const cookie = document.cookie
+      .split("; ")
+      .find((row) => row.startsWith("rikishi-session="));
+    if (cookie) {
+      try {
+        const parsed = JSON.parse(decodeURIComponent(cookie.split("=")[1]));
+        if (parsed.userId && parsed.name) {
+          setSession(parsed);
+        }
+      } catch {
+        // Invalid cookie
+      }
+    }
   }, []);
 
   const login = (user: UserSession) => {
-    localStorage.setItem("rikishi-session", JSON.stringify(user));
     setSession(user);
   };
 
   const logout = () => {
-    localStorage.removeItem("rikishi-session");
     setSession(null);
+    document.cookie = "rikishi-session=;Path=/;Expires=Thu, 01 Jan 1970 00:00:00 GMT";
   };
 
-  return { session, login, logout, hydrated };
+  return { session, login, logout };
+}
+
+interface UserOption {
+  name: string;
+  id: string;
 }
 
 export function UserAuth({
@@ -46,14 +54,22 @@ export function UserAuth({
   onLogout: () => void;
 }) {
   const [users, setUsers] = useState<UserOption[]>([]);
-  const [selectedUser, setSelectedUser] = useState("");
-  const [pin, setPin] = useState("");
+  const [selectedName, setSelectedName] = useState("");
+  const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [migrationState, setMigrationState] = useState<{
+    name: string;
+    pin: string;
+    userId: string;
+    admin: boolean;
+  } | null>(null);
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
 
   useEffect(() => {
     fetch("/api/auth")
       .then((r) => r.json())
-      .then((data) => setUsers(data.users));
+      .then((data) => setUsers(data.users || []));
   }, []);
 
   const handleLogin = async () => {
@@ -61,15 +77,64 @@ export function UserAuth({
     const res = await fetch("/api/auth", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: selectedUser, pin }),
+      body: JSON.stringify({ name: selectedName, password }),
     });
-    if (res.ok) {
-      const data = await res.json();
-      onLogin(data);
-      setPin("");
-    } else {
-      setError("Invalid PIN");
+    const data = await res.json();
+
+    if (!res.ok) {
+      setError(data.error || "Login failed");
+      return;
     }
+
+    if (data.needsPassword) {
+      setMigrationState({
+        name: selectedName,
+        pin: password,
+        userId: data.userId,
+        admin: data.admin,
+      });
+      setPassword("");
+      return;
+    }
+
+    onLogin({ userId: data.userId, name: data.name, admin: data.admin });
+    setSelectedName("");
+    setPassword("");
+  };
+
+  const handleSetPassword = async () => {
+    setError("");
+    if (!migrationState) return;
+
+    if (newPassword.length < 8) {
+      setError("Password must be at least 8 characters");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    const res = await fetch("/api/auth/set-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: migrationState.name,
+        pin: migrationState.pin,
+        password: newPassword,
+      }),
+    });
+    const data = await res.json();
+
+    if (!res.ok) {
+      setError(data.error || "Failed to set password");
+      return;
+    }
+
+    onLogin({ userId: data.userId, name: data.name, admin: data.admin });
+    setMigrationState(null);
+    setNewPassword("");
+    setConfirmPassword("");
   };
 
   if (session) {
@@ -77,23 +142,60 @@ export function UserAuth({
       <div className="flex items-center gap-3">
         <span className="text-retro-yellow font-pixel text-xs">
           {session.name}
-          {session.admin && " *"}
+          {session.admin && " [ADMIN]"}
         </span>
-        <button
-          onClick={onLogout}
-          className="retro-btn text-xs px-2 py-1"
-        >
+        <button onClick={onLogout} className="retro-btn text-xs px-2 py-1">
           LOGOUT
         </button>
       </div>
     );
   }
 
+  // Password setup form (migration from PIN)
+  if (migrationState) {
+    return (
+      <div className="flex flex-col gap-2 items-end">
+        <p className="text-retro-cyan font-pixel text-xs">
+          SET YOUR PASSWORD ({migrationState.name})
+        </p>
+        <div className="flex items-center gap-1 sm:gap-2 flex-wrap justify-end">
+          <input
+            type="password"
+            placeholder="NEW PASSWORD"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            className="retro-input w-24 sm:w-28 text-xs text-center"
+          />
+          <input
+            type="password"
+            placeholder="CONFIRM"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleSetPassword()}
+            className="retro-input w-24 sm:w-28 text-xs text-center"
+          />
+          <button
+            onClick={handleSetPassword}
+            disabled={newPassword.length < 8 || !confirmPassword}
+            className="retro-btn text-xs px-2 py-1"
+          >
+            SAVE
+          </button>
+        </div>
+        <p className="text-gray-500 font-pixel text-xs">MIN 8 CHARACTERS</p>
+        {error && (
+          <span className="text-retro-red text-xs font-pixel">{error}</span>
+        )}
+      </div>
+    );
+  }
+
+  // Login form
   return (
     <div className="flex items-center gap-1 sm:gap-2 flex-wrap justify-end">
       <select
-        value={selectedUser}
-        onChange={(e) => setSelectedUser(e.target.value)}
+        value={selectedName}
+        onChange={(e) => setSelectedName(e.target.value)}
         className="retro-select text-xs max-w-[130px] sm:max-w-none"
       >
         <option value="">PLAYER</option>
@@ -105,19 +207,18 @@ export function UserAuth({
       </select>
       <input
         type="password"
-        maxLength={4}
-        placeholder="PIN"
-        value={pin}
-        onChange={(e) => setPin(e.target.value)}
+        placeholder="PASSWORD"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
         onKeyDown={(e) => e.key === "Enter" && handleLogin()}
-        className="retro-input w-14 sm:w-16 text-xs text-center"
+        className="retro-input w-20 sm:w-24 text-xs text-center"
       />
       <button
         onClick={handleLogin}
-        disabled={!selectedUser || pin.length !== 4}
+        disabled={!selectedName || !password}
         className="retro-btn text-xs px-2 py-1"
       >
-        GO
+        LOGIN
       </button>
       {error && (
         <span className="text-retro-red text-xs font-pixel">{error}</span>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,39 @@
+import bcrypt from "bcryptjs";
+import { NextRequest } from "next/server";
+
+const SALT_ROUNDS = 10;
+
+export interface UserSession {
+  userId: string;
+  name: string;
+  admin: boolean;
+}
+
+export function hashPassword(password: string): string {
+  return bcrypt.hashSync(password, SALT_ROUNDS);
+}
+
+export function verifyPassword(password: string, hash: string): boolean {
+  return bcrypt.compareSync(password, hash);
+}
+
+export const SESSION_COOKIE = "rikishi-session";
+export const SESSION_MAX_AGE = 30 * 24 * 60 * 60; // 30 days
+
+export function getSessionFromRequest(request: NextRequest): UserSession | null {
+  const cookie = request.cookies.get(SESSION_COOKIE);
+  if (!cookie?.value) return null;
+  try {
+    const parsed = JSON.parse(decodeURIComponent(cookie.value));
+    if (parsed.userId && parsed.name && typeof parsed.admin === "boolean") {
+      return parsed as UserSession;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function makeSessionCookieValue(session: UserSession): string {
+  return encodeURIComponent(JSON.stringify(session));
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -102,12 +102,12 @@ function initializeSchema(db: Database.Database) {
 }
 
 function migrateSchema(db: Database.Database) {
-  const columns = db.prepare("PRAGMA table_info(bout_results)").all() as { name: string; notnull: number }[];
-  const colNames = new Set(columns.map((c) => c.name));
+  // Bout results migration: add east_id/west_id columns
+  const boutCols = db.prepare("PRAGMA table_info(bout_results)").all() as { name: string; notnull: number }[];
+  const boutColNames = new Set(boutCols.map((c) => c.name));
 
-  // Need to recreate table if east_id is missing or winner_id is NOT NULL
-  const winnerCol = columns.find((c) => c.name === "winner_id");
-  const needsRecreate = !colNames.has("east_id") || (winnerCol && winnerCol.notnull === 1);
+  const winnerCol = boutCols.find((c) => c.name === "winner_id");
+  const needsRecreate = !boutColNames.has("east_id") || (winnerCol && winnerCol.notnull === 1);
 
   if (needsRecreate) {
     db.exec(`
@@ -124,20 +124,31 @@ function migrateSchema(db: Database.Database) {
       );
       INSERT INTO bout_results_new (id, basho_id, day, east_id, west_id, winner_id, loser_id, kimarite, is_kimboshi)
         SELECT id, basho_id, day,
-          COALESCE(${colNames.has("east_id") ? "east_id" : "winner_id"}, winner_id),
-          COALESCE(${colNames.has("west_id") ? "west_id" : "loser_id"}, loser_id),
+          COALESCE(${boutColNames.has("east_id") ? "east_id" : "winner_id"}, winner_id),
+          COALESCE(${boutColNames.has("west_id") ? "west_id" : "loser_id"}, loser_id),
           winner_id, loser_id, kimarite, is_kimboshi
         FROM bout_results;
       DROP TABLE bout_results;
       ALTER TABLE bout_results_new RENAME TO bout_results;
     `);
   }
+
+  // Users migration: add password_hash and admin columns
+  const userCols = db.prepare("PRAGMA table_info(users)").all() as { name: string }[];
+  const userColNames = new Set(userCols.map((c) => c.name));
+
+  if (!userColNames.has("password_hash")) {
+    db.exec("ALTER TABLE users ADD COLUMN password_hash TEXT");
+  }
+  if (!userColNames.has("admin")) {
+    db.exec("ALTER TABLE users ADD COLUMN admin INTEGER DEFAULT 0");
+  }
 }
 
 function syncUsersFromConfig(db: Database.Database) {
   const config = getConfig();
   const upsert = db.prepare(
-    "INSERT INTO users (id, name) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET name = excluded.name"
+    "INSERT INTO users (id, name, admin) VALUES (?, ?, ?) ON CONFLICT(id) DO UPDATE SET name = excluded.name, admin = excluded.admin"
   );
   const ensureBasho = db.prepare(
     "INSERT OR IGNORE INTO basho (id, status) VALUES (?, 'active')"
@@ -146,7 +157,7 @@ function syncUsersFromConfig(db: Database.Database) {
   const transaction = db.transaction(() => {
     for (const user of config.users) {
       const id = user.name.toLowerCase().replace(/\s+/g, "-");
-      upsert.run(id, user.name);
+      upsert.run(id, user.name, user.admin ? 1 : 0);
     }
     ensureBasho.run(config.basho);
   });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Allow public endpoints
+  if (pathname.startsWith("/api/auth") || pathname === "/api/basho") {
+    return NextResponse.next();
+  }
+
+  // All other /api/* routes require a valid session cookie
+  const sessionCookie = request.cookies.get("rikishi-session");
+  if (!sessionCookie?.value) {
+    return NextResponse.json(
+      { error: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(sessionCookie.value));
+    if (!parsed.userId || !parsed.name) {
+      return NextResponse.json(
+        { error: "Invalid session" },
+        { status: 401 }
+      );
+    }
+    return NextResponse.next();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid session" },
+      { status: 401 }
+    );
+  }
+}
+
+export const config = {
+  matcher: ["/api/((?!auth).*)"],
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,14 @@
 // Config types
 export interface UserConfig {
   name: string;
-  pin: string;
+  pin?: string;
+  admin: boolean;
+}
+
+// Session type
+export interface UserSession {
+  userId: string;
+  name: string;
   admin: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Replaces 4-digit PIN system with bcrypt password authentication (closes #14)
- All API routes protected via Next.js middleware — returns 401 without session cookie
- Front page locked down: unauthenticated users see a landing page with HOME and RULES tabs only
- Existing users migrate via PIN-to-password flow on first login (enter old PIN, then set 8+ char password)
- Admin can reset a user's password, forcing re-migration via PIN
- Session managed via `rikishi-session` cookie (30-day expiry, SameSite=Lax)

## Changes
- **New**: `src/lib/auth.ts` — bcrypt helpers + session cookie parser
- **New**: `src/middleware.ts` — API route auth gate
- **New**: `src/app/api/auth/set-password/route.ts` — PIN-to-password migration endpoint
- **Modified**: All API routes — PIN auth replaced with session cookie
- **Modified**: All components — `pin` prop removed
- **Modified**: `src/app/page.tsx` — landing page with HOME/RULES tabs when logged out
- **Modified**: `src/lib/db.ts` — `password_hash` and `admin` columns added to users table
- **Modified**: `SPEC.md` — auth section rewritten

## Test plan
- [ ] Delete `data/rikishi-rumble.db` and restart — verify fresh migration
- [ ] Visit landing page logged out — should see HOME and RULES tabs only
- [ ] Verify `curl /api/leaderboard` returns 401 without cookie
- [ ] Login with old PIN — should prompt to set password
- [ ] Set password (8+ chars) — should redirect to full app
- [ ] Logout and login with new password — should work
- [ ] Test wrong password — should return error
- [ ] Non-admin user — should get 403 on `/api/sync`
- [ ] Admin password reset — target user forced through PIN migration again

🤖 Generated with [Claude Code](https://claude.com/claude-code)